### PR TITLE
Restrict lock crashfix to iOS15+

### DIFF
--- a/SDWebImage/Core/SDImageIOAnimatedCoder.m
+++ b/SDWebImage/Core/SDImageIOAnimatedCoder.m
@@ -196,7 +196,9 @@ NSLock *kSDImageIOCoderLock;
         kSDImageIOCoderLock = [[NSLock alloc] init];
     });
 
-    [kSDImageIOCoderLock lock];
+    if (@available(iOS 15, *)) {
+        [kSDImageIOCoderLock lock];
+    }
     
     // Some options need to pass to `CGImageSourceCopyPropertiesAtIndex` before `CGImageSourceCreateImageAtIndex`, or ImageIO will ignore them because they parse once :)
     // Parse the image properties
@@ -237,7 +239,9 @@ NSLock *kSDImageIOCoderLock;
         imageRef = CGImageSourceCreateThumbnailAtIndex(source, index, (__bridge CFDictionaryRef)[decodingOptions copy]);
     }
     if (!imageRef) {
-        [kSDImageIOCoderLock unlock];
+        if (@available(iOS 15, *)) {
+            [kSDImageIOCoderLock unlock];
+        }
         return nil;
     }
     // Thumbnail image post-process
@@ -260,7 +264,9 @@ NSLock *kSDImageIOCoderLock;
     UIImage *image = [[UIImage alloc] initWithCGImage:imageRef scale:scale orientation:exifOrientation];
 #endif
     CGImageRelease(imageRef);
-    [kSDImageIOCoderLock unlock];
+    if (@available(iOS 15, *)) {
+        [kSDImageIOCoderLock unlock];
+    }
     return image;
 }
 

--- a/SDWebImage/Core/SDImageIOAnimatedCoder.m
+++ b/SDWebImage/Core/SDImageIOAnimatedCoder.m
@@ -191,7 +191,7 @@ NSLock *kSDImageIOCoderLock API_AVAILABLE(ios(15));
 
 + (UIImage *)createFrameAtIndex:(NSUInteger)index source:(CGImageSourceRef)source scale:(CGFloat)scale preserveAspectRatio:(BOOL)preserveAspectRatio thumbnailSize:(CGSize)thumbnailSize options:(NSDictionary *)options {
     
-    if (@available(iOS 15, *)) {
+    if (@available(iOS 15, tvOS 15, *)) {
         static dispatch_once_t onceToken;
         dispatch_once(&onceToken, ^{
             kSDImageIOCoderLock = [[NSLock alloc] init];
@@ -238,7 +238,7 @@ NSLock *kSDImageIOCoderLock API_AVAILABLE(ios(15));
         imageRef = CGImageSourceCreateThumbnailAtIndex(source, index, (__bridge CFDictionaryRef)[decodingOptions copy]);
     }
     if (!imageRef) {
-        if (@available(iOS 15, *)) {
+        if (@available(iOS 15, tvOS 15, *)) {
             [kSDImageIOCoderLock unlock];
         }
         return nil;
@@ -263,7 +263,7 @@ NSLock *kSDImageIOCoderLock API_AVAILABLE(ios(15));
     UIImage *image = [[UIImage alloc] initWithCGImage:imageRef scale:scale orientation:exifOrientation];
 #endif
     CGImageRelease(imageRef);
-    if (@available(iOS 15, *)) {
+    if (@available(iOS 15, tvOS 15, *)) {
         [kSDImageIOCoderLock unlock];
     }
     return image;

--- a/SDWebImage/Core/SDImageIOAnimatedCoder.m
+++ b/SDWebImage/Core/SDImageIOAnimatedCoder.m
@@ -19,7 +19,7 @@ static NSString * kSDCGImageSourceRasterizationDPI = @"kCGImageSourceRasterizati
 // Specify File Size for lossy format encoding, like JPEG
 static NSString * kSDCGImageDestinationRequestedFileSize = @"kCGImageDestinationRequestedFileSize";
 
-NSLock *kSDImageIOCoderLock;
+NSLock *kSDImageIOCoderLock API_AVAILABLE(ios(15));
 
 @interface SDImageIOCoderFrame : NSObject
 
@@ -191,12 +191,11 @@ NSLock *kSDImageIOCoderLock;
 
 + (UIImage *)createFrameAtIndex:(NSUInteger)index source:(CGImageSourceRef)source scale:(CGFloat)scale preserveAspectRatio:(BOOL)preserveAspectRatio thumbnailSize:(CGSize)thumbnailSize options:(NSDictionary *)options {
     
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        kSDImageIOCoderLock = [[NSLock alloc] init];
-    });
-
     if (@available(iOS 15, *)) {
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            kSDImageIOCoderLock = [[NSLock alloc] init];
+        });
         [kSDImageIOCoderLock lock];
     }
     


### PR DESCRIPTION
Modified the [iOS 15 crash fix](https://github.com/tumblr/SDWebImage/pull/1) to support only iOS 15+.

The crash does not exist on iOS 14 and lower and the lock solution may slow down performance on these devices.
While we are currently in the process of removing iOS 14 support the SDWebImage library still supports iOS9-14 so requires this change in order to merge this in to the main repo.